### PR TITLE
[HOTFIX] Fix OpenSearch description file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,9 +147,9 @@ GEM
     parliament-opensearch (0.2.6)
       activesupport (>= 5.0.0.1)
       feedjira (~> 2.1, >= 2.1.2)
-    parliament-routes (0.3.0)
+    parliament-routes (0.3.1)
     parliament-ruby (0.8.0)
-    parliament-utils (0.2.3)
+    parliament-utils (0.2.4)
       bandiera-client
       coveralls
       haml

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -56,7 +56,7 @@ class SearchController < ApplicationController
   <ShortName>#{I18n.t('pugin.layouts.pugin.website_brand')}</ShortName>
   <Description>Search #{I18n.t('pugin.layouts.pugin.website_brand')} online content</Description>
   <Image height="16" width="16" type="image/x-icon">#{root_url}favicon.ico</Image>
-  <Url type="text/html" template="#{opensearch_description_url}?q={searchTerms}&amp;start_index={startIndex?}&amp;count={count?}" />
+  <Url type="text/html" template="#{search_url}?q={searchTerms}&amp;start_index={startIndex?}&amp;count={count?}" />
 </OpenSearchDescription>
 XML
     render xml: description_file, content_type: 'application/opensearchdescription+xml', layout: false

--- a/app/views/resource/show.html.haml
+++ b/app/views/resource/show.html.haml
@@ -1,12 +1,15 @@
 %table
-  %tbody
+  %thead
     %tr
-      %td Subject
-      %td Predicate
-      %td Object
-
-      - @statements.each do |statement|
-        %tr
-          %td= statement[0]
-          %td= statement[1]
-          %td= statement[2]
+      %th Subject
+      %th Predicate
+      %th Object
+  %tbody
+    - @statements.each do |statement|
+      %tr
+        - statement.each do |section|
+          %td
+            - if section.uri?
+              = link_to section.to_s, section.to_s
+            - else
+              = section

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe SearchController, vcr: true do
   <ShortName>UK Parliament</ShortName>
   <Description>Search UK Parliament online content</Description>
   <Image height="16" width="16" type="image/x-icon">http://test.host/favicon.ico</Image>
-  <Url type="text/html" template="http://test.host/search/opensearch?q={searchTerms}&amp;start_index={startIndex?}&amp;count={count?}" />
+  <Url type="text/html" template="http://test.host/search?q={searchTerms}&amp;start_index={startIndex?}&amp;count={count?}" />
 </OpenSearchDescription>
 XML
 

--- a/spec/views/resource/show.html.haml_spec.rb
+++ b/spec/views/resource/show.html.haml_spec.rb
@@ -2,19 +2,65 @@ require 'rails_helper'
 
 RSpec.describe 'resource/show' do
   before(:each) do
-    @statements = [ ['subject1', 'predicate1', 'object1'], ['subject2', 'predicate2', 'object2'] ]
+    subject1 = double('subject', uri?: true, to_s: 'http://example.com/1' )
+    subject2 = double('subject', uri?: true, to_s: 'http://example.com/2' )
+
+    predicate1 = double('subject', uri?: true, to_s: 'http://example.com/schema/name' )
+    predicate2 = double('subject', uri?: true, to_s: 'http://example.com/schema/hasLink' )
+
+    object1 = double('subject', uri?: false, to_s: 'Matt Rayner' )
+    object2 = double('subject', uri?: true, to_s: 'http://example.com/1' )
+
+    @statements = [ [subject1, predicate1, object1], [subject2, predicate2, object2] ]
     render
   end
 
   context 'table headings' do
     it 'displays the correct titles' do
-      expect(rendered).to match(/Subject/)
-      expect(rendered).to match(/Predicate/)
-      expect(rendered).to match(/Object/)
+      thead = <<HTML
+<thead>
+<tr>
+<th>Subject</th>
+<th>Predicate</th>
+<th>Object</th>
+</tr>
+</thead>
+HTML
+      expect(rendered).to include(thead)
     end
   end
 
-  it 'displays the correct text' do
-    expect(rendered).to match(/subject1/)
+  it 'displays the correct markup for row 1' do
+    row1 = <<HTML
+<tr>
+<td>
+<a href="http://example.com/1">http://example.com/1</a>
+</td>
+<td>
+<a href="http://example.com/schema/name">http://example.com/schema/name</a>
+</td>
+<td>
+Matt Rayner
+</td>
+</tr>
+HTML
+    expect(rendered).to include(row1)
+  end
+
+  it 'displays the correct markup for row 2' do
+    row1 = <<HTML
+<tr>
+<td>
+<a href="http://example.com/2">http://example.com/2</a>
+</td>
+<td>
+<a href="http://example.com/schema/hasLink">http://example.com/schema/hasLink</a>
+</td>
+<td>
+<a href="http://example.com/1">http://example.com/1</a>
+</td>
+</tr>
+HTML
+    expect(rendered).to include(row1)
   end
 end


### PR DESCRIPTION
Fixed Url attribute which was originally pointing to the description
file rather than the search endpoint

Also made an improvement to the resource page to render links when a statements subject, predicate or object was a uri.