### PR TITLE
Search AI tracking events instead of page views

### DIFF
--- a/app/views/search/_status_old_search.haml
+++ b/app/views/search/_status_old_search.haml
@@ -1,2 +1,2 @@
 .status--highlight
-  %p= t('search.new_search', link: link_to(t('search.old_search_linktext'), "https://www.parliament.uk/search/results/?new-search-opt-out=true&q=#{@query_parameter}", data: { type: 'old-search' }, onclick: 'appInsights.trackPageView("search/virtual/back-to-old"); return true;')).html_safe
+  %p= t('search.new_search', link: link_to(t('search.old_search_linktext'), "https://www.parliament.uk/search/results/?new-search-opt-out=true&q=#{@query_parameter}", data: { type: 'old-search' }, onclick: 'appInsights.trackEvent("backToOldSearch"); return true;')).html_safe

--- a/app/views/search/results.haml
+++ b/app/views/search/results.haml
@@ -19,7 +19,7 @@
         - @results.entries.each_with_index do |entry, index|
           %li
             .list--details
-              %h2= link_to(entry.title, entry.url, onclick: "appInsights.trackPageView(\"search/virtual/result/#{start_index(current_page)+index}\"); return true;")
+              %h2= link_to(entry.title, entry.url, onclick: "appInsights.trackEvent(\"resultLinkClicked\", {url: \"#{entry.url}\"}, {position: #{start_index(current_page)+index}}); return true;")
               =#%p.search-result-url=entry.url
               - if entry.content
                 %p= entry.content


### PR DESCRIPTION
Modifies search (result links and bailout link) rendering to inject Application Insights custom event tracking JS instead of virtual page views.