### PR TITLE
[WEBDEV-433] Refactor application of HTML attributes in HAML

### DIFF
--- a/app/views/home/find_your_constituency.html.haml
+++ b/app/views/home/find_your_constituency.html.haml
@@ -7,7 +7,7 @@
     - elsif Parliament::Utils::Helpers::FlagHelper.election?
       = render partial: 'shared/election_message'
 
-%section#content{:tabindex => "0"}
+%section#content{ tabindex: "0" }
   .container
     .block--border__bottom
       .block

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,6 +1,6 @@
 - title 'beta.parliament.uk Home page' # Special case of a title - home page
 
-#content.hero{:tabindex => "0"}
+#content.hero{ tabindex: "0" }
   .container
     %h1= t('.title')
     %p= t('.new_website', link: link_to(t('.new_website_link'), 'https://pds.blog.parliament.uk/2017/02/14/a-new-website-for-parliament-first-public-steps/')).html_safe

--- a/app/views/home/mps.html.haml
+++ b/app/views/home/mps.html.haml
@@ -11,7 +11,7 @@
     .container
       = render partial: 'shared/election_message'
 - else
-  %section#content{:tabindex => "0"}
+  %section#content{ tabindex: "0" }
     .container
       .block--border__bottom
         .block

--- a/app/views/meta/cookie_policy.html.haml
+++ b/app/views/meta/cookie_policy.html.haml
@@ -1,6 +1,6 @@
 - page_title = title(t('.title'))
 
-#content.section--primary{:tabindex => "0"}
+#content.section--primary{ tabindex: "0" }
   .container
     %h1= page_title
     %p= t('.cookie.definition')

--- a/app/views/meta/index.html.haml
+++ b/app/views/meta/index.html.haml
@@ -1,6 +1,6 @@
 - page_title = title(t('.title'))
 
-#content.section--primary{:tabindex => "0"}
+#content.section--primary{ tabindex: "0" }
   .container
     %h1= page_title
 

--- a/app/views/meta/who_should_i_contact_with_my_issue.html.haml
+++ b/app/views/meta/who_should_i_contact_with_my_issue.html.haml
@@ -1,4 +1,4 @@
-#content.section--primary{:tabindex => "0"}
+#content.section--primary{ tabindex: "0" }
   .container.container--offset
     %h1= t('.title')
     %p= t('.intro_text_1')

--- a/app/views/postcodes/_postcode_lookup.html.haml
+++ b/app/views/postcodes/_postcode_lookup.html.haml
@@ -11,9 +11,9 @@
     = label_tag 'input', t('.search_by_postcode')
     = text_field_tag(:postcode, @postcode, value: flash[:postcode], maxlength: 8, pattern:'[0-9a-zA-Z ]{5,}')
     - button_text = @person.nil? && @constituency.nil? ? "Find" : "Check"
-    %button{:id => 'btn_loading', :class => 'btn--primary', :value => button_text, :type => 'submit', :data => { :tracking => 'postcode' }}
+    %button{ id: 'btn_loading', class: 'btn--primary', value: button_text, type: 'submit', data: { tracking: 'postcode' } }
       = button_text
-      %svg{:height => "24", :viewbox => "0 0 128 128", :width => "24", :xmlns => "http://www.w3.org/2000/svg"}
-        %path{:d => "M109.25 55.5h-36l12-12a29.54 29.54 0 0 0-49.53 12H18.75A46.04 46.04 0 0 1 96.9 31.84l12.35-12.34v36zm-90.5 17h36l-12 12a29.54 29.54 0 0 0 49.53-12h16.97A46.04 46.04 0 0 1 31.1 96.16L18.74 108.5v-36z"}
+      %svg{ height: "24", viewbox: "0 0 128 128", width: "24", xmlns: "http://www.w3.org/2000/svg" }
+        %path{ d: "M109.25 55.5h-36l12-12a29.54 29.54 0 0 0-49.53 12H18.75A46.04 46.04 0 0 1 96.9 31.84l12.35-12.34v36zm-90.5 17h36l-12 12a29.54 29.54 0 0 0 49.53-12h16.97A46.04 46.04 0 0 1 31.1 96.16L18.74 108.5v-36z" }
 
 %p= t('.do_not_know_postcode', link: link_to(t('.do_not_know_postcode_link'), 'http://www.royalmail.com/find-a-postcode')).html_safe

--- a/app/views/postcodes/index.html.haml
+++ b/app/views/postcodes/index.html.haml
@@ -1,4 +1,4 @@
-#content.section--primary{:tabindex => "0"}
+#content.section--primary{ tabindex: "0" }
   .container
     %h1= title(t('.title')).capitalize
 

--- a/app/views/postcodes/show.html.haml
+++ b/app/views/postcodes/show.html.haml
@@ -1,4 +1,4 @@
-#content.section--primary{:tabindex => "0"}
+#content.section--primary{ tabindex: "0" }
   .container
     %h1
       %span= title("#{t('.results_for')} #{@postcode.upcase}")
@@ -13,6 +13,6 @@
           %p
             = t('no_content.empty_list.no_mp')
     - else
-      = render partial: "pugin/elements/list", locals: {item_type: "people", data: @person}
+      = render partial: "pugin/elements/list", locals: { item_type: "people", data: @person }
     %p
       = link_to(t('.check_different_postcode').capitalize, postcodes_path)

--- a/app/views/search/_search_box.haml
+++ b/app/views/search/_search_box.haml
@@ -1,8 +1,8 @@
 %form
   .input-group
     %label.sr-only{ for: 'search_box' } Enter a keyword
-    %input{ type: 'search', name: 'q', value: @query_parameter, id: 'search_box', maxlength: '1000', pattern: '^(?!.*<script|<Script).*$'}
-    %button{:id => 'btn_loading', :class => 'btn--primary', :value => 'Search', :type => 'submit', :data => { :tracking => 'search' }}
+    %input{ type: 'search', name: 'q', value: @query_parameter, id: 'search_box', maxlength: '1000', pattern: '^(?!.*<script|<Script).*$' }
+    %button{ id: 'btn_loading', class: 'btn--primary', value: 'Search', type: 'submit', data: { tracking: 'search' } }
       Search
-      %svg{:height => "24", :viewbox => "0 0 128 128", :width => "24", :xmlns => "http://www.w3.org/2000/svg"}
-        %path{:d => "M109.25 55.5h-36l12-12a29.54 29.54 0 0 0-49.53 12H18.75A46.04 46.04 0 0 1 96.9 31.84l12.35-12.34v36zm-90.5 17h36l-12 12a29.54 29.54 0 0 0 49.53-12h16.97A46.04 46.04 0 0 1 31.1 96.16L18.74 108.5v-36z"}
+      %svg{ height: "24", viewbox: "0 0 128 128", width: "24", xmlns: "http://www.w3.org/2000/svg" }
+        %path{ d: "M109.25 55.5h-36l12-12a29.54 29.54 0 0 0-49.53 12H18.75A46.04 46.04 0 0 1 96.9 31.84l12.35-12.34v36zm-90.5 17h36l-12 12a29.54 29.54 0 0 0 49.53-12h16.97A46.04 46.04 0 0 1 31.1 96.16L18.74 108.5v-36z" }

--- a/app/views/search/index.haml
+++ b/app/views/search/index.haml
@@ -1,7 +1,7 @@
 - content_for :title do
   = t('search.index.title')
 
-#content.section--primary{:tabindex => "0"}
+#content.section--primary{ tabindex: "0" }
   .container
     %h1= t('search.index.title')
 

--- a/app/views/search/no_results.haml
+++ b/app/views/search/no_results.haml
@@ -9,7 +9,7 @@
 
     = render partial: 'search_box'
 
-%section#content{:tabindex => "0"}
+%section#content{ tabindex: "0" }
   .container
     = render partial: 'status_old_search'
     = render partial: 'status_no_results'

--- a/app/views/search/results.haml
+++ b/app/views/search/results.haml
@@ -12,7 +12,7 @@
     %p= "About #{@results_total} results"
 
 - if @results_total.to_i >= 1
-  %section#content{:tabindex => "0"}
+  %section#content{ tabindex: "0" }
     .container
       = render partial: 'status_old_search'
       %ol.list--block
@@ -27,7 +27,7 @@
 %section
   .container
     - if @results_total.to_i >= 1
-      %nav.navigation--number{ aria:{ label: 'Pagination' } }
+      %nav.navigation--number{ aria: { label: 'Pagination' } }
         - unless current_page == 1
           = link_to(t('pagination.previous'), search_path(q: @query_parameter, start_index: start_index(previous_page), count: @count).html_safe, { class: "navigation-control--left" })
 


### PR DESCRIPTION
I think the file **no_results.haml** is not being used, which you can find in the directory *views/search*. This feature is getting rendered inside the **results.haml** file instead in the same directory, currently on line 44. Either way, I've updated that page's attribute format --containing `tabindex`-- to use our now standard format from `{:tabindex => "0"}` to `{ tabindex: "0" }`.